### PR TITLE
Update codemirror-github-light-theme.css

### DIFF
--- a/lib/codemirror-github-light-theme.css
+++ b/lib/codemirror-github-light-theme.css
@@ -1,11 +1,20 @@
 /*!
- * GitHub Light v0.4.2
+ * GitHub Light v0.4.3
+ * Modified by Chang Hyun Lyoo
+ * Modification Date 2021-03-03
  * Copyright (c) 2012 - 2017 GitHub, Inc.
  * Licensed under MIT (https://github.com/primer/github-syntax-theme-generator/blob/master/LICENSE)
  */
 .cm-s-github-light.CodeMirror {
   background: #fff;
   color: #24292e; }
+
+.cm-s-github-light .CodeMirror-scroll{
+	border-bottom: 1px solid #ddd;
+    border-radius: 6px 6px 0 0;
+    border: 1px solid;
+    border-color: #ddd #ddd #ccc;
+}
 
 .cm-s-github-light .CodeMirror-gutters {
   background: #fff;
@@ -19,7 +28,9 @@
 
 .cm-s-github-light .CodeMirror-linenumber {
   color: #959da5;
-  padding: 0 16px 0 16px; }
+  padding: 0 16px 0 16px;
+  border-bottom: 1px solid #e9e9e9;
+       }
 
 .cm-s-github-light .CodeMirror-cursor {
   border-left: 1px solid #24292e; }
@@ -83,4 +94,11 @@
   font-weight: normal;
   font-style: normal;
   text-decoration: none;
-  color: #e36209; }
+  color: #24292e; }
+
+.cm-s-github-light .cm-def {
+  color: #6f42c1; }
+ 
+.cm-s-github-light .cm-number {
+	color: #005cc5;  	
+  }


### PR DESCRIPTION
updated colors of _cm-def_ , _cm-numbers_, borderstyle  refer to [gist.github.com](https://gist.github.com/) code snippet theme.